### PR TITLE
[WIP] Generate .ttf instead of .otf

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -23,10 +23,10 @@ SFMONO_MIGU1M = [
     ["modified-SFMono-BoldItalic.otf", "modified-migu-1m-bold-oblique.ttf"],
 ]
 SFMONO_SQUARE = [
-    ["SFMonoSquare-Regular.otf", "build"],
-    ["SFMonoSquare-Bold.otf", "build"],
-    ["SFMonoSquare-RegularItalic.otf", "build"],
-    ["SFMonoSquare-BoldItalic.otf", "build"],
+    ["SFMonoSquare-Regular.ttf", "build"],
+    ["SFMonoSquare-Bold.ttf", "build"],
+    ["SFMonoSquare-RegularItalic.ttf", "build"],
+    ["SFMonoSquare-BoldItalic.ttf", "build"],
 ]
 
 

--- a/src/sfmono_square.py
+++ b/src/sfmono_square.py
@@ -87,7 +87,7 @@ def generate(hankaku, zenkaku, version):
     font.autoHint()
     font.autoInstr()
     print("Generate " + opts["out_file"])
-    font.generate(opts["out_file"], flags=("opentype",))
+    font.generate(opts["out_file"])
     return 0
 
 
@@ -104,7 +104,7 @@ def read_opts(hankaku, zenkaku, version):
         "style": style,
         "fullname": FULLNAME + " " + style,
         "fontname": fontname,
-        "out_file": fontname + ".otf",
+        "out_file": fontname + ".ttf",
     }
 
 


### PR DESCRIPTION
Building .otf, it shows extra spaces on hankaku glyphs on Windows.  It
is because the font files has a strange value of the xAvgCharWidth
property: 1984.  This commit changes the type of fonts: .otf -> .ttf.
Then fontforge can calculate the valid value for it (1984 -> 1024) and
it shows valid spaces on glyphs.

----

Windows 環境で半角文字に余計なスペースが入ってしまう問題を修正します。なぜか ttf にすると `xAvgCharWidth` が正常に計算されるようになります 🤔 ちなみに、otf のままだと、fonttools で強制的に `xAvgCharWidth` を書き換えたとしても、Windows ではうまく表示されません（全角文字まで半角幅になって重なり合ってしまう）。

ただ、そもそもこのフォント、Windows で使っていいの？という問題があるので、そこは別途 Apple に確認する必要あり。

----

`xAvgCharWidth` などの font metrics の確認には [fonttools](https://github.com/fonttools/fonttools) が便利。