### PR TITLE
Fix path to open fonts with Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install with [Homebrew][].
 brew tap delphinus/sfmono-square
 brew install sfmono-square
 
-open $(brew --cellar sfmono-square)/20180318/share/fonts
+open $(brew --cellar sfmono-square)/1.0.0/share/fonts
 # open fonts with Finder
 ```
 


### PR DESCRIPTION
Hi,

I tried to install this font with Homebrew as wrote on README, but couldn't open them with Finder.

Probably it's forgotten to fix with b2fc824, right?