### PR TITLE
macOS Catalina patch

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -19,11 +19,11 @@ class SfmonoSquare < Formula
   def install
     resource("migu1mfonts").stage { buildpath.install Dir["*"] }
 
-    sd_mono_dir_base = "/Applications/Utilities/Terminal.app/Contents/Resources/Fonts"
-    sfmono_dir = if Dir.exist?(sd_mono_dir_base)
-      Pathname.new sd_mono_dir_base
+    sfmono_dir_base = "/Applications/Utilities/Terminal.app/Contents/Resources/Fonts"
+    sfmono_dir = if Dir.exist?(sfmono_dir_base)
+      Pathname.new sfmono_dir_base
     else
-      Pathname.new "/System"+sd_mono_dir_base
+      Pathname.new "/System"+sfmono_dir_base
     end
     [
       "SFMono-Regular.otf",

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -19,7 +19,12 @@ class SfmonoSquare < Formula
   def install
     resource("migu1mfonts").stage { buildpath.install Dir["*"] }
 
-    sfmono_dir = Pathname.new "/Applications/Utilities/Terminal.app/Contents/Resources/Fonts"
+    sd_mono_dir_base = "/Applications/Utilities/Terminal.app/Contents/Resources/Fonts"
+    sfmono_dir = if Dir.exist?(sd_mono_dir_base)
+      Pathname.new sd_mono_dir_base
+    else
+      Pathname.new "/System"+sd_mono_dir_base
+    end
     [
       "SFMono-Regular.otf",
       "SFMono-RegularItalic.otf",


### PR DESCRIPTION
macOS Catalina now has a dedicated system volume which involves the change in location of the system applications at `/Applications` to `/System/Applications`.
The installation script refers to the SF Mono font files located in Terminal.app resources so the directory path needs to be updated to conform new system volume in Catalina.
As Catalina is currently in beta, this patch can be put on hold until official release.