### PR TITLE
Expand shade characters to cover all

### DIFF
--- a/src/sfmono.py
+++ b/src/sfmono.py
@@ -2,7 +2,7 @@
 from os.path import splitext
 
 import fontforge
-import psMat
+from psMat import compose, scale, translate
 
 
 OLD_WIDTH = 1266
@@ -13,6 +13,11 @@ FAMILY = "SF Mono"
 FILE_PREFIX = "SF-Mono-"
 PS_FAMILY = "SFMono"
 FAMILY_SUFFIX = "1x2"
+LIGHT_SHADE = 0x2591  # ░
+MEDIUM_SHADE = 0x2592  # ▒
+DARK_SHADE = 0x2593  # ▓
+LOWER_BLOCK = 0x2581  # ▁
+PRIVATE = 0xE000  # 
 
 
 def modify(in_file):
@@ -25,6 +30,9 @@ def modify(in_file):
     font = fontforge.open(in_file)
     if regular_font:
         font.mergeFonts(regular_font)
+    for code in [LIGHT_SHADE, MEDIUM_SHADE, DARK_SHADE]:
+        _expand_shades(font, code)
+    _add_bar_to_shade_bottom(font)
     _set_proportion(font)
     font.removeOverlap()
     font.familyname = f"{PS_FAMILY} {FAMILY_SUFFIX}"
@@ -48,8 +56,42 @@ def modify(in_file):
     return 0
 
 
+def _expand_shades(font, code):
+    # `421` means the size of a set of pattern in shades.
+    mat = translate(0, 421)
+
+    font.selection.select(code)
+    font.copy()
+    for glyph in list(font.selection.byGlyphs):
+        glyph.transform(mat)
+    font.pasteInto()
+
+
+def _add_bar_to_shade_bottom(font):
+    font.selection.select(LOWER_BLOCK)
+    font.copy()
+    font.selection.select(PRIVATE)
+    font.paste()
+
+    font.selection.select(LOWER_BLOCK)
+    move_to_origin = translate(0, 208)
+    shrink_to_fit = scale(1.0, 106.0 / 256)
+    move_to_bottom = translate(0, -439)
+    mat = compose(compose(move_to_origin, shrink_to_fit), move_to_bottom)
+    for glyph in list(font.selection.byGlyphs):
+        glyph.transform(mat)
+    font.copy()
+    font.selection.select(DARK_SHADE)
+    font.pasteInto()
+
+    font.selection.select(PRIVATE)
+    font.cut()
+    font.selection.select(LOWER_BLOCK)
+    font.paste()
+
+
 def _set_proportion(font):
-    mat = psMat.scale(SCALE_DOWN)
+    mat = scale(SCALE_DOWN)
     font.selection.all()
     for glyph in list(font.selection.byGlyphs):
         glyph.transform(mat)


### PR DESCRIPTION
Tested on iTerm2 v3.3.3beta2

| before | after |
|---|---|
| <img width="217" alt="スクリーンショット 0001-09-03 11 12 54" src="https://user-images.githubusercontent.com/1239245/64139667-aa2dd200-ce3c-11e9-9e9d-a0aaa69a0121.png"> | <img width="214" alt="スクリーンショット 0001-09-03 11 18 07" src="https://user-images.githubusercontent.com/1239245/64139661-a4d08780-ce3c-11e9-953f-cfb0b0916d5a.png"> |
