### PR TITLE
Use the latest SF Mono 15.0d5e1

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -18,7 +18,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "55799d9c23369cf5db3dcd07a4543e39a39f93c2ccd7028d0195a20cbb2fa2ea"
+    sha256 "18d6cc85003bf024023fe80a5551eae281b530742f60af64ab526c07615724f7"
   end
 
   def install

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -3,9 +3,9 @@
 class SfmonoSquare < Formula
   desc "Square-sized SF Mono + Japanese fonts + nerd-fonts"
   homepage "https://github.com/delphinus/homebrew-sfmono-square"
-  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.2.1.tar.gz"
-  sha256 "445d4c6b7e706199cd33624ebeb223d044705e96c5ed063303b76afbe198a780"
-  version "1.2.1"
+  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.2.2.tar.gz"
+  sha256 "50e5a44c2e772fe93112f073c4acaf4409142b83dd3762c3cb74a94bb544277d"
+  version "1.2.2"
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build


### PR DESCRIPTION
diff by [pettarin/glyphIgo][]

[pettarin/glyphIgo]: https://github.com/pettarin/glyphIgo

```diff
--- /tmp/old.txt        2019-09-11 19:27:09.000000000 +0900
+++ /tmp/new.txt        2019-09-11 19:27:25.000000000 +0900
@@ -1,4 +1,4 @@
-[INFO] Glyphs in '/Library/Fonts/SF-Mono-Regular.otf':
+[INFO] Glyphs in '/usr/local/opt/sfmono-square/share/fonts/src/SF-Mono-Regular.otf':
 ' '    32      0x20    SPACE
 'A'    65      0x41    LATIN CAPITAL LETTER A
 'À'    192     0xc0    LATIN CAPITAL LETTER A WITH GRAVE
@@ -205,6 +205,7 @@
 'Ŝ'    348     0x15c   LATIN CAPITAL LETTER S WITH CIRCUMFLEX
 'Ṥ'    7780    0x1e64  LATIN CAPITAL LETTER S WITH ACUTE AND DOT ABOVE
 'Ś'    346     0x15a   LATIN CAPITAL LETTER S WITH ACUTE
+'ẞ'    7838    0x1e9e  LATIN CAPITAL LETTER SHARP S
 'T'    84      0x54    LATIN CAPITAL LETTER T
 'Ṱ'    7792    0x1e70  LATIN CAPITAL LETTER T WITH CIRCUMFLEX BELOW
 'Ṭ'    7788    0x1e6c  LATIN CAPITAL LETTER T WITH DOT BELOW
```