### PR TITLE
Remove support for Sierra on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ jobs:
     # 10.13 High Sierra
     - os: osx
       osx_image: xcode10.1
-    # 10.12 Sierra
-    - os: osx
-      osx_image: xcode9.2
 
 before_cache:
   - brew cleanup


### PR DESCRIPTION
Tests on travis still fails in the Sierra enviroment. So drop it.