### PR TITLE
Fix building process to use the latest fontforge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: ruby
 
 jobs:
   include:
+    # 10.15 Catalina
+    - os: osx
+      osx_image: xcode11.4
     # 10.14 Mojave
     - os: osx
       osx_image: xcode11.3

--- a/bin/sfmono-square
+++ b/bin/sfmono-square
@@ -1,4 +1,4 @@
 #!/bin/bash
 TOP_DIR="$(cd "$(dirname "$0")/.." || exit; pwd -P)"
 VERSION="$1"
-PYTHONPATH=$TOP_DIR:$TOP_DIR/src:$PYTHONPATH python3 -c "import sys; import build; sys.exit(build.build('$VERSION'))"
+PYTHONPATH=$TOP_DIR:$TOP_DIR/src:$PYTHONPATH "$(/usr/local/bin/brew --prefix python@3.8)"/bin/python3 -c "import sys; import build; sys.exit(build.build('$VERSION'))"

--- a/bin/show-font-version.py
+++ b/bin/show-font-version.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/local/opt/python@3.8/bin/python3
 import sys
 
-sys.path.append("/usr/local/opt/fontforge/lib/python3.7/site-packages")
+sys.path.append("/usr/local/opt/fontforge/lib/python3.8/site-packages")
 
 import fontforge
 

--- a/bin/travis-build.sh
+++ b/bin/travis-build.sh
@@ -22,5 +22,5 @@ else
   perl -i -pe 's,(?<=^  url ").*(?="$),$ENV{URL},' $FORMULA
   perl -i -pe 's,(?<=^  sha256 ").*(?="$),$ENV{SHA},' $FORMULA
   perl -i -pe 's,(?<=^  version ").*(?="$),$ENV{HASH},' $FORMULA
-  brew install --build-from-source $FORMULA
+  brew install -vd --build-from-source $FORMULA
 fi

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -9,7 +9,7 @@ class SfmonoSquare < Formula
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build
-  depends_on "python" => :build
+  depends_on "python@3.8" => :build
 
   resource "migu1mfonts" do
     url "https://osdn.jp/frs/redir.php?m=gigenet&f=%2Fmix-mplus-ipa%2F63545%2Fmigu-1m-20150712.zip"
@@ -38,7 +38,7 @@ class SfmonoSquare < Formula
     end
 
     # Set path for fontforge library to use it in Python
-    ENV["PYTHONPATH"] = Formulary.factory("fontforge").opt_lib / "python3.7/site-packages"
+    ENV["PYTHONPATH"] = Formulary.factory("fontforge").opt_lib / "python3.8/site-packages"
 
     # Uncomment and change this value to enlarge glyphs from Migu1M.
     # See https://github.com/delphinus/homebrew-sfmono-square/issues/9

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -37,13 +37,23 @@ class SfmonoSquare < Formula
       end
     end
 
-    # Set path for fontforge library to use it in Python
-    ENV["PYTHONPATH"] = Formulary.factory("fontforge").opt_lib / "python3.8/site-packages"
-
     # Uncomment and change this value to enlarge glyphs from Migu1M.
     # See https://github.com/delphinus/homebrew-sfmono-square/issues/9
     # ENV["MIGU1M_SCALE"] = "82"
-    system buildpath / "bin/sfmono-square", version
+
+    # Set path for fontforge library to use it in Python
+    fontforge_lib = Formulary.factory("fontforge").lib / "python3.8/site-packages"
+    # Supply the full path for Python3.8 executable to use with fontforge
+    python38 = Formulary.factory("python@3.8").bin / "python3"
+
+    system python38, "-c", <<~PYTHON
+      import sys
+      sys.path.append('#{buildpath / "src"}')
+      sys.path.append('#{fontforge_lib}')
+      import build
+      sys.exit(build.build('#{version}'))
+    PYTHON
+
     (share / "fonts").install Dir["build/*.otf"]
     (share / "fonts/src").install Dir["*.otf"]
     (share / "fonts/src").install Dir["*.ttf"]


### PR DESCRIPTION
The latest fontforge formula uses `lib/python3.8/site-packages` to store itself. This PR changes `PYTHONPATH` to use it.