### PR TITLE
Extend timeouts for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - /usr/local/Homebrew
 
 script:
-  - bin/travis-build.sh
+  - travis_wait 30 bin/travis-build.sh
   - bin/show-font-version.py
 
 notifications:


### PR DESCRIPTION
Because the new image for Catalina takes longer time to generate fonts.