### PR TITLE
Fixed SHA256

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -23,7 +23,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "f46a0a74a3e02e9c0304eebe5c8fbbc2211ed32536981df42725c16a0feeebf3"
+    sha256 "61a7d750badddcb9c4af0161aa750dbed42789d34de2facf1781bb48a008e1bd"
   end
 
   def install


### PR DESCRIPTION
# Fixed SHA256 for download SF-Mono.dmg

### SHA256 error when using Homebrew

```
==> Downloading https://developer.apple.com/design/downloads/SF-Mono.dmg
Already downloaded: /Users/hirotaka/Library/Caches/Homebrew/downloads/0460e0518bf6a1c4bf8645a32eab811d8aef26f6e7a24fb44d81e4a237d7afd4--SF-Mono.dmg
Error: SHA256 mismatch
Expected: f46a0a74a3e02e9c0304eebe5c8fbbc2211ed32536981df42725c16a0feeebf3
  Actual: 61a7d750badddcb9c4af0161aa750dbed42789d34de2facf1781bb48a008e1bd
 Archive: /Users/hirotaka/Library/Caches/Homebrew/downloads/0460e0518bf6a1c4bf8645a32eab811d8aef26f6e7a24fb44d81e4a237d7afd4--SF-Mono.dmg
To retry an incomplete download, remove the file above.

```