### PR TITLE
fix: SF Mono sha256

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -23,7 +23,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "d91ed5d03a249b515dd1ba9aba7127dcd85bd1c7d2a3a7687531524b6d9a6a6d"
+    sha256 "fe04fe76d4f3847dc401566c47de14c0d14679d624680671b5d03938bf2ca22f"
   end
 
   def install


### PR DESCRIPTION
Probably `SF-Mono.dmg` has changed.

```console
❯ brew install sfmono-square              
==> Installing sfmono-square from delphinus/sfmono-square
==> Downloading https://osdn.net/projects/mix-mplus-ipa/downloads/72511/migu-1m-20200307.zip
==> Downloading from https://ymu.dl.osdn.jp/mix-mplus-ipa/72511/migu-1m-20200307.zip
######################################################################## 100.0%
==> Downloading https://developer.apple.com/design/downloads/SF-Mono.dmg
==> Downloading from https://devimages-cdn.apple.com/design/resources/download/SF-Mono.dmg
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: d91ed5d03a249b515dd1ba9aba7127dcd85bd1c7d2a3a7687531524b6d9a6a6d
  Actual: fe04fe76d4f3847dc401566c47de14c0d14679d624680671b5d03938bf2ca22f
    File: /Users/teppeis/Library/Caches/Homebrew/downloads/0460e0518bf6a1c4bf8645a32eab811d8aef26f6e7a24fb44d81e4a237d7afd4--SF-Mono.dmg
To retry an incomplete download, remove the file above.
```