### PR TITLE
Avoid to shrink the same glyphs multiple times

### DIFF
--- a/src/sfmono.py
+++ b/src/sfmono.py
@@ -93,6 +93,13 @@ def _add_bar_to_shade_bottom(font):
 def _set_proportion(font):
     mat = scale(SCALE_DOWN)
     font.selection.all()
+    scaled = set()
     for glyph in list(font.selection.byGlyphs):
-        glyph.transform(mat)
+        # some glyphs will be selected multiple times.
+        codepoint = glyph.unicode
+        if codepoint != -1 and codepoint in scaled:
+            print(f"this is already scaled: {codepoint:#x}")
+        else:
+            glyph.transform(mat)
+            scaled.add(codepoint)
         glyph.width = WIDTH


### PR DESCRIPTION
These glyphs below have been scaled down extra times. This patch fixes this and now they have true sizes.

```
- 0x2d
µ 0xb5
Ω 0x3a9
Δ 0x394
‣ 0x2023
```

| before                                                                                                                                                                   | after                                                                                                                                                                    |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="105" alt="スクリーンショット 0002-11-28 0 36 11" src="https://user-images.githubusercontent.com/1239245/100465061-fdf79b80-3111-11eb-9abf-30f412463b9e.png"> | <img width="108" alt="スクリーンショット 0002-11-28 0 35 14" src="https://user-images.githubusercontent.com/1239245/100465069-0354e600-3112-11eb-82a9-145efcad54e5.png"> |

