### PR TITLE
Use `python3` executable instead of `python@3.9`

### DIFF
--- a/bin/show-font-version.py
+++ b/bin/show-font-version.py
@@ -1,4 +1,4 @@
-#!/usr/local/opt/python@3.9/bin/python3
+#!/usr/local/bin/python3
 import sys
 
 sys.path.append("/usr/local/opt/fontforge/lib/python3.9/site-packages")

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -9,7 +9,7 @@ class SfmonoSquare < Formula
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python" => :build
 
   resource "migu1mfonts" do
     output, = system_command curl_executable,
@@ -49,9 +49,7 @@ class SfmonoSquare < Formula
     # Set path for fontforge library to use it in Python
     fontforge_lib = Formulary.factory("fontforge").lib / "python3.9/site-packages"
 
-    python39 = Formulary.factory("python@3.9").bin / "python3"
-
-    system python39, "-c", <<~PYTHON
+    system "python3", "-c", <<~PYTHON
       import sys
       sys.path.append('#{buildpath / 'src'}')
       sys.path.append('#{fontforge_lib}')


### PR DESCRIPTION
Because now `python` formula has python3.9.