### PR TITLE
Use Big Sur instead of Catalina in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     - cron: '25 * * * *'
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: actions/checkout@v2


### PR DESCRIPTION
Avoid for Homebrew to fail installing Python.

```
==> Installing delphinus/sfmono-square/sfmono-square dependency: python@3.9
==> Pouring python@3.9--3.9.7.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.9

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.9

Possible conflicting files are:
/usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/2.7/bin/2to3
```