### PR TITLE
Update SF Mono

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -3,9 +3,9 @@
 class SfmonoSquare < Formula
   desc "Square-sized SF Mono + Japanese fonts + nerd-fonts"
   homepage "https://github.com/delphinus/homebrew-sfmono-square"
-  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.3.2.tar.gz"
-  sha256 "7c0275b8b4f462c6e17b58e9803161eef8403bf5ec77d766083750744a929ec3"
-  version "1.3.2"
+  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.3.3-pre-0.tar.gz"
+  sha256 "bf59e7e607bbd6c79a44ac293d0784c626afeedfdbade836631d254fc66243bc"
+  version "1.3.3-pre-0"
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -23,7 +23,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "ec0518e310797d2f9cb924c18e3e7b661359f4fb653d1ad4315758ebcdb5ff11"
+    sha256 "76c415e9aee0524087cc6a042113db6b38f1a19f2e286f807aa29756461370a9"
   end
 
   def install


### PR DESCRIPTION
Update sha256 for SF-Mono.dmg. This update has no diff in glyphs from the current version.