### PR TITLE
Use Python 3.10 because fontforge use that now

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -9,7 +9,7 @@ class SfmonoSquare < Formula
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   resource "migu1mfonts" do
     output, = system_command curl_executable,
@@ -47,11 +47,11 @@ class SfmonoSquare < Formula
     # ENV["MIGU1M_SCALE"] = "82"
 
     # Set path for fontforge library to use it in Python
-    fontforge_lib = Formulary.factory("fontforge").lib / "python3.9/site-packages"
+    fontforge_lib = Formulary.factory("fontforge").lib / "python3.10/site-packages"
 
-    python39 = Formulary.factory("python@3.9").bin / "python3"
+    python310 = Formulary.factory("python@3.10").bin / "python3"
 
-    system python39, "-c", <<~PYTHON
+    system python310, "-c", <<~PYTHON
       import sys
       sys.path.append('#{buildpath / 'src'}')
       sys.path.append('#{fontforge_lib}')

--- a/src/migu1m.py
+++ b/src/migu1m.py
@@ -51,8 +51,8 @@ def _set_new_em(font):
     """
     font.selection.all()
     font.unlinkReferences()
-    font.ascent = float(ASCENT) / EM * OLD_EM
-    font.descent = float(DESCENT) / EM * OLD_EM
+    font.ascent = round(float(ASCENT) / EM * OLD_EM)
+    font.descent = round(float(DESCENT) / EM * OLD_EM)
     font.em = EM
 
 
@@ -65,7 +65,7 @@ def _set_proportion(font):
         trans = psMat.translate(x_to_center, 0)
         mat = psMat.compose(scale, trans)
         glyph.transform(mat)
-        glyph.width = EM / 2 if is_hankaku_kana else EM
+        glyph.width = round(EM / 2) if is_hankaku_kana else EM
 
 
 def _zenkaku_space(font):

--- a/src/sfmono_square.py
+++ b/src/sfmono_square.py
@@ -225,4 +225,4 @@ def _hankaku_glyphs(font):
         font.selection.select(("more", "unicode"), i)
     for glyph in font.selection.byGlyphs:
         glyph.transform(mat)
-        glyph.width = WIDTH / 2
+        glyph.width = round(WIDTH / 2)


### PR DESCRIPTION
Now fontforge formula needs python@3.10 to build.