### PR TITLE
Update sha256 for SF-Mono.dmg

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -23,7 +23,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "8e78534e64b2e49f0c268b5bb08f20e61c68b608efc836dc7329a3001c1a8d8c"
+    sha256 "ba59a1bb9917cbe03bfff7eb9c3da6cc1b3aab9271f2be8ac30698ee09a86183"
   end
 
   def install

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -3,9 +3,9 @@
 class SfmonoSquare < Formula
   desc "Square-sized SF Mono + Japanese fonts + nerd-fonts"
   homepage "https://github.com/delphinus/homebrew-sfmono-square"
-  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.4.3.tar.gz"
-  sha256 "248372ee548072a7ce99e479fdb1a75f8dd2fa0412c6c1da98a4c120336cde9a"
-  version "1.4.3"
+  url "https://github.com/delphinus/homebrew-sfmono-square/archive/v1.4.4-testing-01.tar.gz"
+  sha256 "4de21555b0a3f7627fe48c105b85da171c5d7ef92c4e096a273823d503b59bdc"
+  version "1.4.4-testing-01"
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build


### PR DESCRIPTION
* SF Mono Version 16.0d2e1 → 18.0d1e1
  - The version number has been bumped up. Glyphs included are not changed.