### PR TITLE
Avoid conflicting with python@3.11

### DIFF
--- a/bin/github-build.sh
+++ b/bin/github-build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eux
-sw_vers # show macOS version
+sw_vers                              # show macOS version
+brew uninstall python@3.10 azure-cli # avoid conflicting with python@3.11
 brew update
 brew upgrade
 if [[ $GITHUB_REF = refs/heads/master ]]; then

--- a/bin/github-build.sh
+++ b/bin/github-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 sw_vers # show macOS version
 brew update
+brew upgrade
 if [[ $GITHUB_REF = refs/heads/master ]]; then
   : build on the latest tag
   brew tap delphinus/sfmono-square


### PR DESCRIPTION
The image of GitHub Actions includes `azure-cli` formula that needs `python@3.10`. This conflicts `python@3.11` that is needed by `fontforge`. This patch removes `azure-cli` before installing.