### PR TITLE
fix: use valid hash for SF-Mono.dmg

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -25,7 +25,7 @@ class SfmonoSquare < Formula
 
   resource "sfmono" do
     url "https://developer.apple.com/design/downloads/SF-Mono.dmg"
-    sha256 "abaf6d62cd5b17ae1837ab40a35386733a3f603cf641a84cf59b1d7fb4caac39"
+    sha256 "a6a91880966db4a287a936286c1523b9dd1f5bbf5d4b9b5dcd8276df07bd4d6e"
   end
 
   def install


### PR DESCRIPTION
fix #93 