### PR TITLE
fix: fix the link for Migu fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Thoughts and detail description here:
 ### font source
 
 * SF Mono: Apple
-* Migu 1M: [Miguフォント : M+とIPAの合成フォント](http://mix-mplus-ipa.osdn.jp/migu/)
+* Migu 1M: [Miguフォント : M+とIPAの合成フォント](https://itouhiro.github.io/mixfont-mplus-ipa/migu/)
 * Nerd Fonts: [ryanoasis/nerd-fonts: Iconic font aggregator, collection, and patcher. 40+ patched fonts, over 3,600 glyph/icons, includes popular collections such as Font Awesome & fonts such as Hack](https://github.com/ryanoasis/nerd-fonts)
 
 And, idea and some code is from [プログラミング用フォント Ricty](http://www.rs.tus.ac.jp/yyusa/ricty.html).

--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -18,11 +18,9 @@ class SfmonoSquare < Formula
                              args: ["--version"],
                              print_stderr: true
     curl_name_and_version = output.sub(/^.*?lib(?=curl)/, "").sub(/\s+.*/m, "")
-    # url "https://osdn.net/projects/mix-mplus-ipa/downloads/72511/migu-1m-20200307.zip",
-    # url "https://github.com/delphinus/homebrew-sfmono-square/files/12063197/migu-1m-20200307.zip",
-    url "https://github.com/delphinus/homebrew-sfmono-square/files/13533559/migu-1m-20200307.tar.gz",
+    url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v2020.0307/migu-1m-20200307.zip",
         user_agent: curl_name_and_version
-    sha256 "042449f5e98a2631afbc0512f73f8dd612abf109e0b1a2356f174bd742e9ef40"
+    sha256 "e4806d297e59a7f9c235b0079b2819f44b8620d4365a8955cb612c9ff5809321"
   end
 
   resource "sfmono" do


### PR DESCRIPTION
The site of Migu font family is moved to the new URL below. https://itouhiro.github.io/mixfont-mplus-ipa/migu/