### PR TITLE
feat: update some props with fonttools

### DIFF
--- a/sfmono-square.rb
+++ b/sfmono-square.rb
@@ -10,6 +10,7 @@ class SfmonoSquare < Formula
   head "https://github.com/delphinus/homebrew-sfmono-square.git"
 
   depends_on "fontforge" => :build
+  depends_on "fonttools" => :build
   depends_on "python@3.12" => :build
   depends_on "pod2man" => :build
 
@@ -60,12 +61,14 @@ class SfmonoSquare < Formula
     # ENV["MIGU1M_SCALE"] = "82"
 
     fontforge_lib = Formula["fontforge"].lib / "python3.12/site-packages"
+    fonttools_lib = Formula["fonttools"].lib / "python3.12/site-packages"
     python312 = Formula["python@3.12"].bin / "python3.12"
 
     system python312, "-c", <<~PYTHON
       import sys
       sys.path.append('#{buildpath / 'src'}')
       sys.path.append('#{fontforge_lib}')
+      sys.path.append('#{fonttools_lib}')
       import build
       sys.exit(build.build('#{version}'))
     PYTHON

--- a/src/build.py
+++ b/src/build.py
@@ -6,6 +6,7 @@ import font_patcher
 import migu1m
 import sfmono
 import sfmono_square
+import fonttools
 
 
 MIGU1M = [["migu-1m-regular.ttf"], ["migu-1m-bold.ttf"]]
@@ -23,11 +24,12 @@ SFMONO_MIGU1M = [
     ["SFMono-1x2-BoldItalic.otf", "modified-migu-1m-bold-oblique.ttf"],
 ]
 SFMONO_SQUARE = [
-    ["SFMonoSquare-Regular.otf", "build"],
-    ["SFMonoSquare-Bold.otf", "build"],
-    ["SFMonoSquare-RegularItalic.otf", "build"],
-    ["SFMonoSquare-BoldItalic.otf", "build"],
+    ["SFMonoSquare-Regular.otf", "Regular"],
+    ["SFMonoSquare-Bold.otf", "Bold"],
+    ["SFMonoSquare-RegularItalic.otf", "RegularItalic"],
+    ["SFMonoSquare-BoldItalic.otf", "BoldItalic"],
 ]
+OUT_DIR = "build"
 
 
 def build(version):
@@ -45,7 +47,12 @@ def build(version):
     if concurrent_execute(sfmono_square.generate, args):
         return 1
     print("---- adding nerd-fonts glyphs ----")
-    if concurrent_execute(font_patcher.patch, SFMONO_SQUARE):
+    args = [[a[0], OUT_DIR] for a in SFMONO_SQUARE]
+    if concurrent_execute(font_patcher.patch, args):
+        return 1
+    print("---- overwriting table with fonttools")
+    args = [[f"{OUT_DIR}/{a[0]}", a[1]] for a in SFMONO_SQUARE]
+    if concurrent_execute(fonttools.update, args):
         return 1
     return 0
 

--- a/src/fonttools.py
+++ b/src/fonttools.py
@@ -1,0 +1,31 @@
+# -*- coding:utf-8 -*-
+from fontTools.ttLib import TTFont
+from os import rename
+from tempfile import mkstemp
+
+X_AVG_CHAR_WIDTH = 1024
+FS_SELECTION = {
+    "Regular": 0b00000001_01000000,
+    "RegularItalic": 0b00000001_00000001,
+    "Bold": 0b00000001_00100000,
+    "BoldItalic": 0b00000001_00100001,
+}
+MAC_STYLE = {
+    "Regular": 0b00,
+    "RegularItalic": 0b10,
+    "Bold": 0b01,
+    "BoldItalic": 0b11,
+}
+
+
+def update(fontname, style):
+    font = TTFont(fontname)
+    font["post"].isFixedPitch = 1
+    font["CFF "].cff[0].isFixedPitch = 1
+    font["OS/2"].xAvgCharWidth = X_AVG_CHAR_WIDTH
+    font["OS/2"].fsSelection = FS_SELECTION[style]
+    font["head"].macStyle = MAC_STYLE[style]
+    new_fontname = mkstemp(suffix=".otf")[1]
+    font.save(new_fontname)
+    font.close()
+    rename(new_fontname, fontname)

--- a/src/sfmono_square.py
+++ b/src/sfmono_square.py
@@ -48,8 +48,6 @@ STYLE_PROPERTY = {
         "panose_weight": 5,
         "panose_letterform": 2,
         "italic_angle": 0,
-        "os2_stylemap": 0b0001000000,
-        "macstyle": 0b00,
     },
     "Bold": {
         "weight": "Bold",
@@ -57,8 +55,6 @@ STYLE_PROPERTY = {
         "panose_weight": 8,
         "panose_letterform": 2,
         "italic_angle": 0,
-        "os2_stylemap": 0b0000100000,
-        "macstyle": 0b01,
     },
     "RegularItalic": {
         "weight": "Normal",
@@ -66,8 +62,6 @@ STYLE_PROPERTY = {
         "panose_weight": 5,
         "panose_letterform": 9,
         "italic_angle": ITALIC_ANGLE,
-        "os2_stylemap": 0b0001000001,
-        "macstyle": 0b10,
     },
     "BoldItalic": {
         "weight": "Bold",
@@ -75,8 +69,6 @@ STYLE_PROPERTY = {
         "panose_weight": 8,
         "panose_letterform": 9,
         "italic_angle": ITALIC_ANGLE,
-        "os2_stylemap": 0b0000100001,
-        "macstyle": 0b11,
     },
 }
 
@@ -199,9 +191,6 @@ def new_font(opts):
     # linegap is for gap between lines.  The `hhea_` version is for macOS.
     font.os2_typolinegap = 0
     font.hhea_linegap = 0
-    # Contents of these props always mean the same.
-    font.os2_stylemap = prop["os2_stylemap"]
-    font.macstyle = prop["macstyle"]
     return font
 
 


### PR DESCRIPTION
Fixed some props that cannot be changed by fontforge but by fonttools.

<dl>
<dt><code>isFixedPitch</code></dt>
<dd>This is needed to be shown in “monospace” in FontBook.app.<br>
<img width="869" alt="スクリーンショット 2024-01-13 0 43 48" src="https://github.com/delphinus/homebrew-sfmono-square/assets/1239245/20ca7fe6-3ec8-40eb-9b49-ca4fe5f974d6"></dd>
<dt><code>xAvgCharWidth</code></dt>
<dd>This is for be shown validly in Windows. (But SF Mono Square itself cannot be used in Windows.)</dd>
<dt><code>fsSelection</code></dt>
<dd>FontForge cannot set this validly. FontTools can</dd>
<dt><code>macStyle</code></dt>
<dd>The same as <code>fsSelection</code></dd>
</dl>