### PR TITLE
Wait for the build check to appear before releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See screenshots for examples [here][].
 
 `bin/release` only checks the tree (on `master`, clean, up to date with `origin`, notes written, build check green) and pushes the tag `vX.Y.Z`. Everything else is done by [the release workflow][]: it creates the release from the notes and commits the formula that points at the new tag (`url` / `version` / `sha256`) into `master`.
 
-Nothing is released unless the fonts are built from the very commit the tag points at. The workflow waits while the build check of the commit is running, and stops when it is not successful or does not exist. This is checked on the workflow, so tagging without `bin/release` cannot skip it.
+Nothing is released unless the fonts are built from the very commit the tag points at. The workflow waits for the build check of the commit to start and to finish, and stops when it is not successful or when it never appears. This is checked on the workflow, so tagging without `bin/release` cannot skip it.
 
 [the release workflow]: .github/workflows/release.yml
 

--- a/bin/github-release.sh
+++ b/bin/github-release.sh
@@ -7,6 +7,9 @@ NOTES_DIR=.github/release-notes
 # The build takes 15-25 minutes, so wait for a while when it is still running.
 BUILD_TRIES=70
 BUILD_INTERVAL=30
+# When a tag is pushed just after a merge, the check runs of the commit are not
+# registered yet. Wait for them to appear, but not as long as the build itself.
+BUILD_NONE_TRIES=10
 
 abort() {
   echo "::error::$1"
@@ -31,6 +34,7 @@ main() {
 # points at. Note that this cannot be skipped by tagging without bin/release.
 wait_for_build() {
   sha=$(git rev-parse "$1^{commit}")
+  none=0
   for _ in $(seq $BUILD_TRIES); do
     state=$(build_state "$sha")
     case $state in
@@ -43,7 +47,11 @@ wait_for_build() {
       sleep $BUILD_INTERVAL
       ;;
     none)
-      abort "no build check is found for $sha. Tag a commit built on master."
+      none=$((none + 1))
+      [[ $none -lt $BUILD_NONE_TRIES ]] ||
+        abort "no build check is found for $sha. Tag a commit built on master."
+      echo "the build check for $sha has not started yet"
+      sleep $BUILD_INTERVAL
       ;;
     *)
       abort "the build check for $sha is not successful"

--- a/bin/release
+++ b/bin/release
@@ -7,6 +7,8 @@
 # Set FORCE=1 to skip the check for the build status of HEAD.
 NOTES_DIR=.github/release-notes
 WORKFLOW=https://github.com/delphinus/homebrew-sfmono-square/actions/workflows/release.yml
+NONE_TRIES=6
+NONE_INTERVAL=10
 
 abort() {
   echo "$1" >&2
@@ -47,27 +49,37 @@ check_build() {
     echo 'gh is not installed. skip the check for the build status' >&2
     return
   fi
-  state=$(
-    gh api "repos/{owner}/{repo}/commits/$(git rev-parse HEAD)/check-runs?per_page=100" --jq '
-      [.check_runs[] | select(.name | startswith("build "))]
-      | if length == 0 then "none"
-        elif any(.status != "completed") then "running"
-        elif all(.conclusion == "success") then "success"
-        else "failure" end
-    '
-  )
-  case $state in
-  success) ;;
-  running)
-    echo 'the build check for HEAD is still running. The workflow waits for it.' >&2
-    ;;
-  none)
-    abort 'no build check is found for HEAD. Push it to master first.'
-    ;;
-  *)
-    abort 'the build check for HEAD is not successful.'
-    ;;
-  esac
+  # The check runs are not registered right after a push, so wait a while
+  # before deciding that the commit is not built at all.
+  for _ in $(seq $NONE_TRIES); do
+    case $(build_state) in
+    success)
+      return
+      ;;
+    running)
+      echo 'the build check for HEAD is still running. The workflow waits for it.' >&2
+      return
+      ;;
+    none)
+      echo 'the build check for HEAD has not started yet' >&2
+      sleep $NONE_INTERVAL
+      ;;
+    *)
+      abort 'the build check for HEAD is not successful.'
+      ;;
+    esac
+  done
+  abort 'no build check is found for HEAD. Push it to master first.'
+}
+
+build_state() {
+  gh api "repos/{owner}/{repo}/commits/$(git rev-parse HEAD)/check-runs?per_page=100" --jq '
+    [.check_runs[] | select(.name | startswith("build "))]
+    | if length == 0 then "none"
+      elif any(.status != "completed") then "running"
+      elif all(.conclusion == "success") then "success"
+      else "failure" end
+  '
 }
 
 [[ ${BASH_SOURCE[0]} = "$0" ]] && main "$@"


### PR DESCRIPTION
Closes the race that was found while cutting v3.4.0.

## Problem

The check runs of a commit are not registered on GitHub right after it is pushed. The gate added
in #140 treated "no build check for this commit" as fatal at once, so tagging just after a merge
would have failed the release with `no build check is found for <sha>`, leaving a tag without a
release behind.

v3.4.0 avoided it only because the tag was pushed after the build of `master` had finished.

## Fix

`wait_for_build()` now waits for the check runs to appear (10 tries x 30s = 5 min) before giving
up, in addition to waiting while they are running (70 tries x 30s). `bin/release` does the same
for a shorter while (6 x 10s), so that it can be run right after a merge.

Nothing else changes: a build that is not successful still stops the release, and a commit that
is really never built still fails after the wait.

## Checked

* `shellcheck` and `actionlint` are clean.
* `check_build` against a commit that is not the tip of a push (`a2d5b45`, never built): waits the
  given number of times, then aborts with `no build check is found for HEAD`.
* `check_build` against `HEAD` while its build is running: warns and lets the tag be pushed.
